### PR TITLE
データの個数を取得するメソッドを追加しました。

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,19 @@ Medjedb.get_information(0)
 #=> {"ID"=>0, "パラメータ1"=>"test0", "sample1"=>"test1", "sample2"=>"test2", "sample3"=>"test3"}
 ```
 
+データの個数は `get_infomation_count()` で取得できます。
+```ruby
+#ex.
+Medjedb.get_information(1)
+#=> {"id"=>"1", "パラメータ1"=>"test0", "sample1"=>"test1", "sample2"=>"test2", "sample3"=>"test3"}
+Medjedb.get_information(2)
+#=> {"id"=>"2", "パラメータ1"=>"test0", "sample1"=>"test1", "sample2"=>"test2", "sample3"=>"test3"}
+Medjedb.get_information(3)
+#=> {}
+Medjedb.get_information_count()
+#=> 3
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/medjedb.rb
+++ b/lib/medjedb.rb
@@ -37,4 +37,12 @@ module Medjedb
 
     @medjedb_core.find_information(info_id)
   end
+
+  # データの要素数を取得する
+  def self.get_information_count()
+    raise "DBが初期化されていません." if (!@medjedb_core)
+
+    @medjedb_core.get_information_length()
+  end
+
 end

--- a/lib/medjedb/medjedb_core.rb
+++ b/lib/medjedb/medjedb_core.rb
@@ -47,4 +47,9 @@ class MedjedbCore
     return {} if dm.nil?
     return dm.get_hash()
   end
+
+  # データの要素数を取得する
+  def get_information_length()
+    DataMaster.count
+  end
 end


### PR DESCRIPTION
## 概要
 * Medjedbのデータ個数を取得するケースが出てきたため、メソッドを追加しました。

## 修正内容
 * 以下のメソッドを追加しました。
   * `Medjedb:get_information_count()`
   * `MedjedbCore:get_information_length()`